### PR TITLE
Fix/study sessions: 공부 세션 라우트 응답 개선

### DIFF
--- a/routers/study-sessions.js
+++ b/routers/study-sessions.js
@@ -96,7 +96,7 @@ router.get('/resume', verifySupabaseJWT, async (req, res) => {
 
     const last_paused_at = new Date(session.last_paused_at);
     const resume_at = new Date();
-    const accumulatedPauseSeconds = Number(session.accumulatedPauseSeconds || 0) + Math.floor((resume_at.getTime() - last_paused_at.getTime()) / 1000);
+    const accumulatedPauseSeconds = Number(session.accumulatedPauseSeconds || 0) + ((resume_at.getTime() - last_paused_at.getTime()) / 1000);
     const duration = calculate_duration(session.start_time, resume_at.toISOString(), accumulatedPauseSeconds);
 
     await redisClient.hSet(redis_key, {
@@ -136,7 +136,7 @@ router.get('/finish', verifySupabaseJWT, async (req, res) => {
     // 일시정지된 세션에서 바로 종료하는 경우
     if(session.status === 'paused'){
         const last_paused_at = new Date(session.last_paused_at);
-        const accumulatedPauseSeconds = Number(session.accumulatedPauseSeconds||0) + Math.floor((stopped_at.getTime() - last_paused_at.getTime())/1000);
+        const accumulatedPauseSeconds = Number(session.accumulatedPauseSeconds||0) + ((stopped_at.getTime() - last_paused_at.getTime())/1000);
         await redisClient.hSet(redis_key, {accumulatedPauseSeconds: accumulatedPauseSeconds});
         session = await redisClient.hGetAll(redis_key);
         console.log(`일시정지 상태에서 바로 종료: ${redis_key}`);
@@ -251,7 +251,7 @@ router.post('/session-to-record', verifySupabaseJWT, async (req, res) => {
 function calculate_duration(start_time, end_time, accumulatedPauseSeconds) {
     const end = new Date(end_time);
     const start = new Date(start_time);
-    const duration = Math.floor((end.getTime() - start.getTime()) / 1000) - accumulatedPauseSeconds;
+    const duration = ((end.getTime() - start.getTime()) / 1000) - accumulatedPauseSeconds;
     return duration;
 }
 


### PR DESCRIPTION
1. 일시정지 상태에서 공부 종료 시 업데이트된 누적 일시정지 시간 응답 안되는 이슈 해결
2. 타이머가 흘러가는 동안 duration의 값은 계속 바뀌므로, 시각을 기준으로 계산하도록 누적 일시정지 시간을 응답하도록 함
3. 즉 순 공부시간 = (기기 현재시각) - (시작시각) - (누적 일시정지 시간)으로 계산함
4. 일시정지, 종료 시에는 요청 이후에 시간이 흐르지 않으므로 duration을 보내줌