### PR TITLE
Fix/symbols 비밀번호 재설정 특수문자 허용

### DIFF
--- a/public/update_password.html
+++ b/public/update_password.html
@@ -130,7 +130,7 @@ button:hover {
       const pw1 = document.getElementById('new-password').value;
       const pw2 = document.getElementById('confirm-password').value;
 
-      const pwRegex = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,20}$/;
+      const pwRegex = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*])[A-Za-z\d!@#$%^&*]{8,20}$/;
 
       // 메시지 초기화
       errorMessage.style.display = 'none';


### PR DESCRIPTION
비밀번호 재설정 로직 중 새로운 비밀번호의 유효성을 확인하는 코드에서 특수문자를 포함하지 못하는 문제 생겨서 수정하였음