### PR TITLE
feat: stats, record: 최근 방문, 단일 기록 응답 정합성 개선 및 wallpaper/type 매핑 적용

### DIFF
--- a/routers/photo-management.js
+++ b/routers/photo-management.js
@@ -153,10 +153,6 @@ router.post('/records/:recordId', verifySupabaseJWT, upload.single('file'), asyn
             .select()
             .single()
             .setHeader('Authorization', req.headers.authorization);
-
-            if (updateError) {
-                console.error('업데이트 실패', updateError);
-            }
             
         if (insertError) {
             // Storage 롤백


### PR DESCRIPTION
record.js
- 단일 기록 조회에서 공간 타입을 db 대신 Google Place types으로 산출하도록 조회
- 총 시간과 순공부시간 동시 제공 (총시간 = 시작 ~ 종료, 순 공부시간 = DB에 저장되어있는 duration)

stats.js
- 최근 방문한 공간 조회에서 한 공간당 1개가 아니라 세션 단위로 모두 반환
- 각 세션의 무드 태그를 사용해 getMoodWallpaper로 space_image_url 생성 (문자열)