### PR TITLE
fix: 구글 장소 사진 1개만 가져오기 적용 및 최근 방문 공간 문제 해결

### DIFF
--- a/lib/photoTools.js
+++ b/lib/photoTools.js
@@ -26,9 +26,7 @@ async function _getPhotoNames(...spaceIds) {
     // 결과에서 사진 이름을 추출
     results.forEach(result => {
         if (result.photos) {
-            result.photos.forEach(photo => {
-                ret.push(photo.name);
-            });
+            ret.push(result.photos[0].name);
         }
     })
     return ret;
@@ -43,7 +41,7 @@ async function getPhotoUrls(...spaceIds) {
     var ret = {};
     // 공간 ID별로 빈 배열 초기화
     spaceIds.forEach(spaceId => {
-        ret[spaceId] = [];
+        ret[spaceId] = null;
     })
 
     const fetchPromises = photoData.map(photo_name =>{
@@ -65,7 +63,7 @@ async function getPhotoUrls(...spaceIds) {
     const results = await Promise.allSettled(fetchPromises);
     results.forEach(async (res) => {
         if (res.status === 'fulfilled' && res.value.photoUri) {
-            ret[res.value.spaceId].push(res.value.photoUri);
+            ret[res.value.spaceId] = res.value.photoUri;
         }
     });
 

--- a/routers/stats.js
+++ b/routers/stats.js
@@ -290,7 +290,7 @@ router.get("/my/spaces-ranks", verifySupabaseJWT, async (req, res) => {
 
                 myRanks.push({
                     space_name: spaceNamesMap[spaceId] || spaceInfo?.name,
-                    space_image_url: spacePhotos[spaceId] || [],
+                    space_image_url: spacePhotos[spaceId] || null,
                     my_study_count: myStats.study_count,
                     my_total_minutes: myStats.total_minutes,
                 });
@@ -424,9 +424,10 @@ router.get('/my/recent-spaces', verifySupabaseJWT, async (req, res) => {
       (studyRecords || []).map(async (rec) => {
         const moods = Array.isArray(rec?.study_record_mood_tags)
           ? rec.study_record_mood_tags
-              .map(m => m?.mood_tags?.mood_id)
+              .map(m => m?.mood_tags?.mood_id.trim())
               .filter(Boolean)
           : [];
+        console.log('공간 ID:', rec.space_id, '연관된 무드 IDs:', moods);
         const { url } = await photoTools.getMoodWallpaper(moods || []);
         return { recordId: rec.id, url: url || null };
       })


### PR DESCRIPTION
1. google api로 공간 사진 가져오는 부분 단일 url만 반환하도록 변경
2. 최근 방문 공간 라우트에서 mood_id 에 trim 적용하여 문제 해결