### PR TITLE
fix: 기록 캘린더 API 응답 구조 단순화 및 count 추가

### DIFF
--- a/routers/record.js
+++ b/routers/record.js
@@ -445,6 +445,7 @@ router.get("/records/calendar", async (req, res) => {
         const { data: records, error } = await supabase
             .from("study_record")
             .select(`
+              id,
               duration,
               start_time,
               space_id,
@@ -519,9 +520,10 @@ router.get("/records/calendar", async (req, res) => {
             }
 
             const card = {
-                total_time,
+                id: record.id,
+                duration: total_time,
                 space_name: spaceName ?? null,
-                image_url: imageUrl ?? null
+                space_image_url: imageUrl ?? null
             };
             recordsByDay[day].records.push(card);
         }


### PR DESCRIPTION
- 응답 필드를 total_time, space_name, image_url만 남기고 단순화
- 기록이 2개 이상일 경우 count 필드 추가